### PR TITLE
Sanitize image `crop` and escape image attributes to prevent stored XSS

### DIFF
--- a/images/helpers.php
+++ b/images/helpers.php
@@ -86,10 +86,36 @@ function add_resizing_settings_to_image_path($url, $width, $height, $crop) {
 			}
 		}
 
-		$crop == false ? $crop = 0 : '';
+		$crop = paws_sanitize_image_crop($crop);
 
 		return home_url('/images/width=' . $width . ',height=' . $height . ',crop=' . $crop . '/' . $url);
 	}
+}
+
+function paws_sanitize_image_crop($crop) {
+	if ($crop === false || $crop === '' || $crop === null || $crop === 0 || $crop === '0') {
+		return 0;
+	}
+
+	$normalized_crop = strtolower(str_replace(' ', '-', trim((string) $crop)));
+	$allowed_crop_positions = array(
+		'center',
+		'left',
+		'right',
+		'top',
+		'bottom',
+		'left-top',
+		'left-center',
+		'left-bottom',
+		'center-top',
+		'center-center',
+		'center-bottom',
+		'right-top',
+		'right-center',
+		'right-bottom',
+	);
+
+	return in_array($normalized_crop, $allowed_crop_positions, true) ? $normalized_crop : 0;
 }
 
 /** 
@@ -121,12 +147,10 @@ function replace_image_url_with_resized_url_and_add_srcset(
 		}
 
 		if ($crop !== false && array_key_exists('crop', $attributes[$attributeName])) {
-			$imageCropPosition = $attributes[$attributeName]['crop'];
-			$imageCropPosition = str_replace(' ', '-', $imageCropPosition);
-			$crop = $imageCropPosition;
+			$crop = paws_sanitize_image_crop($attributes[$attributeName]['crop']);
 		}
 
-		$crop == false ? $crop = 0 : '';
+		$crop = paws_sanitize_image_crop($crop);
 	} else {
 		// Fallback to old logic if imageObject does not exist
 		$image_url = isset($attributes["imageUrl"]) ? $attributes["imageUrl"] : false;
@@ -198,14 +222,14 @@ function get_image_attributes(
 			}
 
 			$image_attributes = '
-				src="' . $resized_image_url . '" 
-				srcset="' . $srcset . '"
-				width="' . $width . '"
-				height="' . $height . '"
-				alt="' . $image_alt . '"';
-			$lazy_load == true ? $image_attributes .= 'loading="lazy"' : '';
-			$sizes ? $image_attributes .= 'sizes="' . $sizes . '"' : '';
-			$class ? $image_attributes .= 'class="' . $class . '"' : '';
+				src="' . esc_url($resized_image_url) . '" 
+				srcset="' . esc_attr($srcset) . '"
+				width="' . esc_attr($width) . '"
+				height="' . esc_attr($height) . '"
+				alt="' . esc_attr($image_alt) . '"';
+			$lazy_load == true ? $image_attributes .= ' loading="lazy"' : '';
+			$sizes ? $image_attributes .= ' sizes="' . esc_attr($sizes) . '"' : '';
+			$class ? $image_attributes .= ' class="' . esc_attr($class) . '"' : '';
 
 			return $image_attributes;
 		}


### PR DESCRIPTION
### Motivation
- A `crop` value taken from block attributes was concatenated into resized image URLs and injected into `src`/`srcset` attributes without validation or escaping, creating a stored XSS path.
- The change aims to prevent untrusted editor-controlled values from injecting quotes or attributes into rendered image tags while preserving valid crop behavior.

### Description
- Added `paws_sanitize_image_crop()` which normalizes input and enforces a strict allow-list of supported crop positions, returning `0` for invalid values.
- Replaced previous loose crop handling with calls to `paws_sanitize_image_crop()` when building resize URLs and when reading the `crop` attribute from block data.
- Escaped all generated image attribute outputs with `esc_url()` and `esc_attr()` for `src`, `srcset`, `width`, `height`, `alt`, `sizes`, and `class` to prevent attribute injection.
- Kept fallback behavior for empty/false crop values and preserved existing size calculations when `crop` is not set.

### Testing
- Ran PHP syntax check with `php -l images/helpers.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dedbc08f488333a3b41b4529657377)