### PR TITLE
Limit public image resize dimensions

### DIFF
--- a/images/serve.php
+++ b/images/serve.php
@@ -97,8 +97,16 @@ add_action('init', function () {
 
 
 		// get width, height & crop values
-		$width = array_key_exists('width', $options_key_value_array) ? $options_key_value_array['width'] : 0;
-		$height = array_key_exists('height', $options_key_value_array) ? $options_key_value_array['height'] : 0;
+		$max_dimension = absint(apply_filters('base_image_max_dimension', 4000));
+		$max_dimension = $max_dimension > 0 ? $max_dimension : 4000;
+		$width = min(
+			absint(array_key_exists('width', $options_key_value_array) ? $options_key_value_array['width'] : 0),
+			$max_dimension
+		);
+		$height = min(
+			absint(array_key_exists('height', $options_key_value_array) ? $options_key_value_array['height'] : 0),
+			$max_dimension
+		);
 		$crop = false;
 
 		if (array_key_exists('crop', $options_key_value_array)) {


### PR DESCRIPTION
### Motivation
- The public `/images/` handler accepted user-supplied `width`/`height` and passed them verbatim to Fly resize logic, enabling unauthenticated resource-exhaustion DoS through very large or many unique sizes.
- The change caps dimensions to prevent expensive processing and cache/disk growth while preserving existing resize functionality for normal requests.

### Description
- Introduce a configurable upper bound via the `base_image_max_dimension` filter (default `4000`) and normalize it with `absint`.
- Normalize parsed `width` and `height` with `absint` and clamp each value with `min(..., $max_dimension)` before calling `fly_get_attachment_image_src()`.
- Preserve existing `crop` parsing and downstream behavior, so only the size inputs are constrained.

### Testing
- Ran a PHP syntax check with `php -l images/serve.php` which completed successfully. 
- No additional automated tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dedbecda1c8333bcc93572391322c4)