### PR TITLE
Remove default `site_admin` role assignment to prevent privilege escalation

### DIFF
--- a/backend/user_roles.php
+++ b/backend/user_roles.php
@@ -54,11 +54,6 @@ add_action('init', function () {
 });
 
 /*
-* Change the default role to our new one
-*/
-add_filter('pre_option_default_role', fn () => 'site_admin');
-
-/*
 * Remove 'Administrator' from the list of roles if the current user is not an admin
 */
 add_filter('editable_roles', function ($roles) {


### PR DESCRIPTION
### Motivation
- Remove the filter that set the default role to `site_admin` because it granted new users user-management capabilities and created a privilege-escalation risk when registration or user creation is exposed.

### Description
- Deleted the `add_filter('pre_option_default_role', fn () => 'site_admin');` override from `backend/user_roles.php`, keeping the custom `site_admin` role creation intact but restoring WordPress' default-role behavior for new accounts.

### Testing
- Ran `php -l backend/user_roles.php` which reported no syntax errors, and verified the removal with `git diff -- backend/user_roles.php`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dedc8073648333a029db1e42854f88)